### PR TITLE
Fix signature in message response in order to fix hardhat deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/hardhat-plugin",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/hardhat-plugin",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "ISC",
       "dependencies": {
         "@nilfoundation/niljs": "^0.9.0",

--- a/src/handlers/blockNumber.ts
+++ b/src/handlers/blockNumber.ts
@@ -1,13 +1,40 @@
 import type { HandlerContext } from "../context";
+import { executeOriginalFunction } from "../interceptors";
+import { shardNumber } from "../utils/conversion";
 
 export async function blockNumber(
   method: string,
   params: any[],
   context: HandlerContext,
 ) {
+  const preparedMethod = "eth_getBlockByNumber";
   if (context.debug) {
-    console.log(`Method ${method} params ${JSON.stringify(params)}`);
-    console.log("Response 0x0");
+    console.log("Method", preparedMethod);
   }
-  return "0x0";
+  const result = await executeOriginalFunction(
+    preparedMethod,
+    prepareInput(context),
+    context,
+  );
+  const adaptResponse = adaptResult(result);
+  if (context.debug) {
+    console.log("Response", JSON.stringify(adaptResponse));
+  }
+  return adaptResponse;
+}
+
+function prepareInput(context: HandlerContext): any[] {
+  return [
+    context.hre.config.shardId ?? shardNumber(context.wallet.getAddressHex()),
+    "latest",
+    false,
+  ];
+}
+
+function adaptResult(result: any): any {
+  if (!result) {
+    return "0x0";
+  }
+
+  return result.number;
 }

--- a/src/handlers/getTransactionByHash.ts
+++ b/src/handlers/getTransactionByHash.ts
@@ -24,7 +24,7 @@ export async function getTransactionByHash(
   );
   const adaptResponse = adaptResult(result);
   if (context.debug) {
-    console.log(`Response ${adaptResponse}`);
+    console.log(`Response ${JSON.stringify(adaptResponse)}`);
   }
   return adaptResponse;
 }
@@ -74,6 +74,11 @@ function adaptResult(result: any): any {
     if (typeof result.gasPrice !== "string") {
       result.gasPrice = String(result.gasPrice);
     }
+  }
+
+  if (result.signature === "0x") {
+    // Hardhat wants a signature, so we'll give it a fake one.
+    result.signature = `0x${"00".repeat(64)}`;
   }
 
   result.nonce = result.seqno;


### PR DESCRIPTION
Hardhat test hanged, because it received an incorrect signature and somehow ate the error (I found it during debug).
We need to return anything of 64 bytes with `0x` prefix if the signature is empty.

After that it hanged due to the block number always being 0 (it tries to get enough confirmations). Fixed getting block number here as well.

package-lock.json is updated this way each time I run `npm install`, so why not commit it as well.